### PR TITLE
added cwd (current working directory) property

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ optionally the cache will be cleared in between.
 
 ## Options
 
+- `cwd` (optional, default: `$WERCKER_ROOT`) Location of package.json
 - `clear-cache-on-failed` (optional, default: `true`) If npm fails, clear the
   cache before trying again.
 - `use-cache` (optional, default: `true`) Use the npm cache.
@@ -26,6 +27,10 @@ build:
 The MIT License (MIT)
 
 # Changelog
+
+## 1.1.5
+
+- Added `cwd` (current working directory)
 
 ## 1.1.4
 

--- a/run.sh
+++ b/run.sh
@@ -32,6 +32,14 @@ clear_cache() {
 }
 
 npm_install() {
+  source_dir="$WERCKER_ROOT/$WERCKER_NPM_INSTALL_CWD"
+  if cd "$source_dir";
+  then
+      debug "changed directory $source_dir"
+  else
+      fail "unable to change directory to $source_dir"
+  fi
+
   local retries=3;
   for try in $(seq "$retries"); do
     info "Starting npm install, try: $try"

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,7 +1,10 @@
 name: npm-install
-version: 1.1.4
+version: 1.1.5
 description: npm-install step
 properties:
+  cwd:
+    type: string
+    require: false
   clear-cache-on-failed:
     type: bool
     default: true


### PR DESCRIPTION
To allow for different `package.json` files to be included (e.g.: when submodules are included).

I used the name `cwd` as it's used in the `script` step, but this could also be `source-dir` as per the `s3sync` step.